### PR TITLE
Deprecate Paperplane.io

### DIFF
--- a/services/paperplane/config.json
+++ b/services/paperplane/config.json
@@ -2,10 +2,11 @@
   "config": {
     "name": "paperplane",
     "label": "Paperplane.io",
+    "deprecated": true,
     "description": "Radically simple static hosting.",
     "category": "hosting"
   },
-  "records": [ 
+  "records": [
     {
       "type": "ALIAS",
       "content": "proxy.paperplane.io",


### PR DESCRIPTION
According to their website they are fully offline as of 2020-04-20

https://www.paperplane.io/

> After almost 9 years on the internet, Paperplane shut down on April 20, 2020.
