### PR TITLE
Updates webflow configuration

### DIFF
--- a/services/webflow/config.json
+++ b/services/webflow/config.json
@@ -9,18 +9,18 @@
     {
       "name": "first_record",
       "label": "A Record",
-      "description": "Use the value for the first A record from your Webflow hosting tab.",
+      "description": "Use the value for the first A record from your Webflow hosting tab."
     },
     {
       "name": "second_record",
       "label": "A Record",
-      "description": "Use the value for the second A record from your Webflow hosting tab.",
+      "description": "Use the value for the second A record from your Webflow hosting tab."
     },
     {
       "name": "cname_record",
       "label": "CNAME Record",
-      "description": "Use the value for the CNAME record from your Webflow hosting tab.",
-    },
+      "description": "Use the value for the CNAME record from your Webflow hosting tab."
+    }
   ],
   "records": [
     {

--- a/services/webflow/config.json
+++ b/services/webflow/config.json
@@ -6,18 +6,39 @@
     "category": "hosting"
   },
   "fields": [
-
-  ],
-  "records": [ 
     {
-      "type": "ALIAS",
-      "content": "proxy.webflow.com",
+      "name": "first_record",
+      "label": "A Record",
+      "description": "Use the value for the first A record from your Webflow hosting tab.",
+    },
+    {
+      "name": "second_record",
+      "label": "A Record",
+      "description": "Use the value for the second A record from your Webflow hosting tab.",
+    },
+    {
+      "name": "cname_record",
+      "label": "CNAME Record",
+      "description": "Use the value for the CNAME record from your Webflow hosting tab.",
+    },
+  ],
+  "records": [
+    {
+      "type": "A",
+      "name": "",
+      "content": "{{first_record}}",
+      "ttl": 3600
+    },
+    {
+      "type": "A",
+      "name": "",
+      "content": "{{second_record}}",
       "ttl": 3600
     },
     {
       "name": "www",
       "type": "CNAME",
-      "content": "proxy.webflow.com",
+      "content": "{{cname_record}}",
       "ttl": 3600
     }
   ]


### PR DESCRIPTION
Fixes #94. This PR updates the one-click service for Webflow.

Based on their documentation https://university.webflow.com/article/connecting-a-custom-domain#update-the-dns, the one-click service has been updated to:

1. Prompt for two A records
2. Prompt for one CNAME record

# 👀 How to test this

1. Checkout this branch.
2. From the DNSimple app, point the services rake file to your local repo.
```
# File: lib/tasks/services.rake
5     sh("git clone /Users/me/projects/dnsimple/dnsimple-services tmp/dnsimple-services")
```
3. From the DNSimple app, execute `rake services:import`
4. From the DNSimple app, add the Webflow one-click service to any domain. You should be prompted to enter two A records for the root/apex, and a CNAME record that will be added to the "www" subdomain.
5. On `/services`, you should see Webflow listed