### PR TITLE
Clarify wording for Heroku's DNS target

### DIFF
--- a/services/heroku/config.json
+++ b/services/heroku/config.json
@@ -8,14 +8,14 @@
   "fields": [
     {
       "name": "apexdomain",
-      "label": "Heroku Apex App Name",
-      "description": "Your Heroku Apex DNS name.",
+      "label": "Apex DNS Target",
+      "description": "The DNS Target supplied by Heroku for the apex/naked domain.",
       "example": "apex-meta-foo.herokudns.com"
     },
     {
       "name": "wwwdomain",
-      "label": "Heroku WWW App Name",
-      "description": "Your Heroku WWW DNS name.",
+      "label": "WWW DNS Target",
+      "description": "The DNS Target supplied by Heroku for the WWW subdomain.",
       "example": "www-meta-foo.herokudns.com"
     }
   ],


### PR DESCRIPTION
This PR clarifies the label text for Heroku's fields.

Belongs to https://github.com/dnsimple/dnsimple-services/issues/99