### PR TITLE
Netlify: yoursite.netlify.com -> yoursite.netlify.app

### DIFF
--- a/services/netlify/config.json
+++ b/services/netlify/config.json
@@ -9,21 +9,21 @@
     {
       "name": "site",
       "label": "Netlify Site Name",
-      "description": "Your site name is part of your Netlify URL, for example: in yoursite.netlify.com the app name is yoursite",
-      "append": ".netlify.com",
+      "description": "Your site name is part of your Netlify URL, for example: in yoursite.netlify.app the app name is yoursite",
+      "append": ".netlify.app",
       "example": "yoursite"
     }
   ],
   "records": [
     {
       "type": "ALIAS",
-      "content": "{{site}}.netlify.com",
+      "content": "{{site}}.netlify.app",
       "ttl": 3600
     },
     {
       "name": "www",
       "type": "CNAME",
-      "content": "{{site}}.netlify.com",
+      "content": "{{site}}.netlify.app",
       "ttl": 3600
     }
   ]


### PR DESCRIPTION
Netlify made this change last year so probably smart to update this template, even though netlify.com CNAMEs still work as of now.

- https://answers.netlify.com/t/changes-coming-to-netlify-site-urls-com-to-app/8918
- https://docs.netlify.com/domains-https/custom-domains/configure-external-dns/#configure-a-subdomain

Thanks! :)