### PR TITLE
Add the deprecated flag for the Cloudflare one-click service

### DIFF
--- a/services/cloudflare/config.json
+++ b/services/cloudflare/config.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "deprecated": true,
     "name": "cloudflare",
     "label": "CloudFlare",
     "description": "Protect and accelerate your web site.",


### PR DESCRIPTION
We are removing support for Cloudflare as a one-click service as the API they provided for this is no longer maintained.