### PR TITLE
Fix record type for iCloud+

### DIFF
--- a/services/icloud-plus/config.json
+++ b/services/icloud-plus/config.json
@@ -34,7 +34,7 @@
       "ttl": 3600
     },
     {
-      "type": "TXT",
+      "type": "CNAME",
       "name": "sig1._domainkey",
       "content": "sig1.dkim.{{domain}}.at.icloudmailadmin.com",
       "prio": 10,


### PR DESCRIPTION
We made a mistake on the configuration of iCloud+ records. According to https://support.apple.com/en-us/HT212524, we need a CNAME for DKIM and not TXT
<img width="491" alt="Screenshot 2022-10-24 at 09 57 35" src="https://user-images.githubusercontent.com/80610/197476227-0ba75c3a-5d1a-46fb-a8ff-a3104d2ce0de.png">
