### PR TITLE
RFC-compliant SRV record content

### DIFF
--- a/services/fastmail/config.json
+++ b/services/fastmail/config.json
@@ -78,42 +78,42 @@
     {
       "name": "_client._smtp",
       "type": "SRV",
-      "content": "1 1 {{domain}}",
+      "content": "1 1 {{domain}}.",
       "ttl": 3600,
       "prio": 1
     },
     {
       "name": "_submission._tcp",
       "type": "SRV",
-      "content": "1 587 smtp.fastmail.com",
+      "content": "1 587 smtp.fastmail.com.",
       "ttl": 3600,
       "prio": 0
     },
     {
       "name": "_imaps._tcp",
       "type": "SRV",
-      "content": "1 993 imap.fastmail.com",
+      "content": "1 993 imap.fastmail.com.",
       "ttl": 3600,
       "prio": 0
     },
     {
       "name": "_pop3s._tcp",
       "type": "SRV",
-      "content": "1 995 pop.fastmail.com",
+      "content": "1 995 pop.fastmail.com.",
       "ttl": 3600,
       "prio": 10
     },
     {
       "name": "_carddavs._tcp",
       "type": "SRV",
-      "content": "1 443 carddav.fastmail.com",
+      "content": "1 443 carddav.fastmail.com.",
       "ttl": 3600,
       "prio": 0
     },
     {
       "name": "_caldavs._tcp",
       "type": "SRV",
-      "content": "1 443 caldav.fastmail.com",
+      "content": "1 443 caldav.fastmail.com.",
       "ttl": 3600,
       "prio": 0
     }

--- a/services/office-365/config.json
+++ b/services/office-365/config.json
@@ -75,14 +75,14 @@
     },
     {
       "name": "_sip._tls",
-      "content": "1 443 sipdir.online.lync.com",
+      "content": "1 443 sipdir.online.lync.com.",
       "type": "SRV",
       "prio": 100,
       "ttl": 3600
     },
     {
       "name": "_sipfederationtls._tcp",
-      "content": "1 5061 sipfed.online.lync.com",
+      "content": "1 5061 sipfed.online.lync.com.",
       "type": "SRV",
       "prio": 100,
       "ttl": 3600


### PR DESCRIPTION
This PR:
- Updates the SRV records defined in 1 click services to include the final dot `.` (so called empty label according to [RFC1035](https://www.rfc-editor.org/rfc/rfc1035)). The reason for this is that it is enforced by the record validations.
- The affected services are:
  - Office 365
  - Fastmail