### PR TITLE
Replace SPF type with TXT

### DIFF
--- a/services/fastmail/config.json
+++ b/services/fastmail/config.json
@@ -70,8 +70,8 @@
       "content": "fm3.{{domain}}.dkim.fmhosted.com",
       "ttl": 3600
     },
-      {
-      "type": "SPF",
+    {
+      "type": "TXT",
       "content": "v=spf1 include:spf.messagingengine.com ~all",
       "ttl": 3600
     },

--- a/services/google-apps/config.json
+++ b/services/google-apps/config.json
@@ -7,50 +7,50 @@
   },
   "records": [
     {
+      "type": "CNAME",
       "name": "mail",
       "content": "ghs.googlehosted.com",
-      "type": "CNAME",
       "ttl": 3600
     },
     {
+      "type": "CNAME",
       "name": "calendar",
       "content": "ghs.googlehosted.com",
-      "type": "CNAME",
       "ttl": 3600
     },
     {
-      "content": "aspmx.l.google.com",
       "type": "MX",
+      "content": "aspmx.l.google.com",
       "ttl": 3600,
       "prio": 1
     },
     {
+      "type": "MX",
       "content": "alt1.aspmx.l.google.com",
-      "type": "MX",
       "ttl": 3600,
       "prio": 5
     },
     {
+      "type": "MX",
       "content": "alt2.aspmx.l.google.com",
-      "type": "MX",
       "ttl": 3600,
       "prio": 5
     },
     {
+      "type": "MX",
       "content": "alt3.aspmx.l.google.com",
-      "type": "MX",
       "ttl": 3600,
       "prio": 10
     },
     {
+      "type": "MX",
       "content": "alt4.aspmx.l.google.com",
-      "type": "MX",
       "ttl": 3600,
       "prio": 10
     },
     {
+      "type": "TXT",
       "content": "v=spf1 a include:_spf.google.com ~all",
-      "type": "SPF",
       "ttl": 3600
     }
   ]

--- a/services/icloud-plus/config.json
+++ b/services/icloud-plus/config.json
@@ -41,7 +41,7 @@
       "ttl": 3600
     },
     {
-      "type": "SPF",
+      "type": "TXT",
       "content": "v=spf1 include:icloud.com ~all",
       "ttl": 3600
     }

--- a/services/mailgun/config.json
+++ b/services/mailgun/config.json
@@ -7,7 +7,7 @@
   },
   "records": [
     {
-      "type": "SPF",
+      "type": "TXT",
       "content": "v=spf1 include:mailgun.org ~all",
       "ttl": 3600
     },

--- a/services/office-365/config.json
+++ b/services/office-365/config.json
@@ -22,68 +22,68 @@
   ],
   "records": [
     {
-      "content": "{{verification}}",
       "type": "TXT",
+      "content": "{{verification}}",
       "ttl": 3600
     },
-     {
-      "content": "{{mx}}.mail.protection.outlook.com",
+    {
       "type": "MX",
+      "content": "{{mx}}.mail.protection.outlook.com",
       "prio": 0,
       "ttl": 3600
     },
-     {
+    {
+      "type": "CNAME",
       "name": "autodiscover",
       "content": "autodiscover.outlook.com",
-      "type": "CNAME",
       "ttl": 3600
     },
     {
+      "type": "CNAME",
       "name": "lyncdiscover",
       "content": "webdir.online.lync.com",
-      "type": "CNAME",
       "ttl": 3600
     },
     {
+      "type": "CNAME",
       "name": "msoid",
       "content": "clientconfig.microsoftonline-p.net",
-      "type": "CNAME",
       "ttl": 3600
     },
     {
+      "type": "CNAME",
       "name": "sip",
       "content": "sipdir.online.lync.com",
-      "type": "CNAME",
       "ttl": 3600
     },
     {
+      "type": "CNAME",
       "name": "enterpriseregistration",
       "content": "enterpriseregistration.windows.net",
-      "type": "CNAME",
       "ttl": 3600
     },
     {
+      "type": "CNAME",
       "name": "enterpriseenrollment",
       "content": "enterpriseenrollment.manage.microsoft.com",
-      "type": "CNAME",
       "ttl": 3600
     },
     {
+      "type": "TXT",
       "content": "v=spf1 include:spf.protection.outlook.com -all",
-      "type": "SPF",
       "ttl": 3600
     },
     {
+      "type": "SRV",
       "name": "_sip._tls",
       "content": "1 443 sipdir.online.lync.com.",
-      "type": "SRV",
       "prio": 100,
       "ttl": 3600
     },
     {
+      "type": "SRV",
       "name": "_sipfederationtls._tcp",
       "content": "1 5061 sipfed.online.lync.com.",
-      "type": "SRV",
       "prio": 100,
       "ttl": 3600
     }

--- a/services/postmark-dmarc/config.json
+++ b/services/postmark-dmarc/config.json
@@ -14,10 +14,10 @@
       "example": "v=DMARC1; p=none; pct=100; rua=mailto:re+asdfasdf5zi@dmarc.postmarkapp.com; sp=none; aspf=r;"
     }
   ],
-  "records": [ 
+  "records": [
     {
-      "name": "_dmarc",
       "type": "TXT",
+      "name": "_dmarc",
       "content": "{{dmarc_value}}",
       "ttl": 3600
     }


### PR DESCRIPTION
SPF record type is deprecated. The current standard recommends to use a TXT instead. In our system, we still accept SPF today (that will change eventually), and we create an alternate TXT record when a SPF is created.

Keeping around SPFs is an unnecessary complication.

Belongs to https://github.com/dnsimple/dnsimple-business/issues/727
