### PR TITLE
Bump Ruby version to 3.2.4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 # Update also: .rubocop.yml
-ruby 3.2.3
+ruby 3.2.4


### PR DESCRIPTION
Bump Ruby version to 3.2.4

Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/201