### PR TITLE
Updates Google Workspace MX records

### DIFF
--- a/services/google-apps/config.json
+++ b/services/google-apps/config.json
@@ -7,51 +7,10 @@
   },
   "records": [
     {
-      "type": "CNAME",
-      "name": "mail",
-      "content": "ghs.googlehosted.com",
-      "ttl": 3600
-    },
-    {
-      "type": "CNAME",
-      "name": "calendar",
-      "content": "ghs.googlehosted.com",
-      "ttl": 3600
-    },
-    {
       "type": "MX",
-      "content": "aspmx.l.google.com",
+      "content": "smtp.google.com",
       "ttl": 3600,
       "prio": 1
-    },
-    {
-      "type": "MX",
-      "content": "alt1.aspmx.l.google.com",
-      "ttl": 3600,
-      "prio": 5
-    },
-    {
-      "type": "MX",
-      "content": "alt2.aspmx.l.google.com",
-      "ttl": 3600,
-      "prio": 5
-    },
-    {
-      "type": "MX",
-      "content": "alt3.aspmx.l.google.com",
-      "ttl": 3600,
-      "prio": 10
-    },
-    {
-      "type": "MX",
-      "content": "alt4.aspmx.l.google.com",
-      "ttl": 3600,
-      "prio": 10
-    },
-    {
-      "type": "TXT",
-      "content": "v=spf1 a include:_spf.google.com ~all",
-      "ttl": 3600
     }
   ]
 }


### PR DESCRIPTION
This PR updates Google Workspace service to use Google's current single MX record `smtp.google.com` instead of the legacy `aspmx` set: https://knowledge.workspace.google.com/admin/domains/set-up-mx-records-for-google-workspace

Google Workspace now documents one MX record as the current setup:
- smtp.google.com
- priority 1
- host `blank`
- TTL default, or 1 per Google’s example

Google also says the old `aspmx`... set is legacy but still supported, and that if email is already working, no changes are required. They explicitly note that domains set up before 2023 may still use the old values, and any account can use the new single MX record instead.

## QA

1. Check out this branch.
2. Update your dnsimple-app to pull services from this branch:
```diff
diff --git a/lib/tasks/services.rake b/lib/tasks/services.rake
index 3d37a2ccc9..4b403605a1 100644
--- a/lib/tasks/services.rake
+++ b/lib/tasks/services.rake
@@ -6,11 +6,7 @@ namespace :services do
   task clone_repository: [:clobber_repository] do
     repo = "dnsimple/dnsimple-services.git"
     destination = "tmp/dnsimple-services"
-    if ENV["SERVICE_FETCH_USE_HTTP"] == "1"
-      sh("git clone --depth 1 https://github.com/#{repo} #{destination}")
-    else
-      sh("git clone --depth 1 git@github.com:#{repo} #{destination}")
-    end
+    sh("git clone /Users/sbastn/projects/dnsimple/dnsimple-services tmp/dnsimple-services")
   end
```
3. Run `rake services:import` from dnsimple-app
4. Navigate to any domain on dnsimple-app
5. Add the one-click service: verify that the preview matches the records on this PR.
6. Verify that the correct DNS records exist on the zone.

### Post merge

- [x] Run `dnsimple-rails services:load_templates` in each environment

### Preview
<img width="1191" height="360" alt="Screenshot 2026-03-30 at 14 22 37" src="https://github.com/user-attachments/assets/c730bd6c-87f5-4867-9375-765616062c96" />

### Records created
<img width="482" height="196" alt="Screenshot 2026-03-30 at 14 23 01" src="https://github.com/user-attachments/assets/572acdda-82eb-45ee-83a4-d7b0407df4ec" />